### PR TITLE
Improve Job Queue and split VThingTV model from ThingVisor to resolve MVCC_READ_CONFLICT

### DIFF
--- a/master-controller/src/controller.ts
+++ b/master-controller/src/controller.ts
@@ -32,7 +32,8 @@ import {
 } from "./config";
 import * as k8s from "@kubernetes/client-node";
 import * as mqtt from "mqtt";
-import {mqttCallBack, onTvOutControlMessage, thingVisorUser} from "./mqttcallback";
+import {mqttCallBack,
+  onTvOutControlMessage, thingVisorUser} from "./mqttcallback";
 import {
   convertEnv,
   convertHostAliases,

--- a/master-controller/src/index.ts
+++ b/master-controller/src/index.ts
@@ -122,6 +122,7 @@ async function main() {
   })
   mqttClient.on('message', async (topic:string, message:Buffer) => {
     if(mqttCallBack.has(topic)){
+      logger.debug("Executing Callback of"+topic);
       const callback = mqttCallBack.get(topic)!;
       await callback(message);
     }else{

--- a/master-controller/src/mqttcallback.ts
+++ b/master-controller/src/mqttcallback.ts
@@ -8,33 +8,26 @@ import {deleteThingVisorOnKubernetes, outControlSuffix, thingVisorPrefix} from "
 export const mqttCallBack = new Map<string,(message:Buffer) => Promise<void>>();
 export const thingVisorUser = new Map<string, string>();
 
+
 export const onTvOutControlMessage = async (message:Buffer) => {
   const res = JSON.parse(message.toString().replace("\'", "\""));
   logger.debug("Receiverd Test Callback command");
   if(res.command == "createVThing"){
-    await addBackgroundJob(
-        jobQueue!,
-        "create_thingvisor_vthing",
-        thingVisorUser.get(res.thingVisorID)!,
-        res,
-    );
+    await onMessageCreateVThing(res);
   }else if(res.command == "destroyTVAck"){
-    await addBackgroundJob(
-        jobQueue!,
-        "destroy_thingvisor_ack",
-        thingVisorUser.get(res.thingVisorID)!,
-        res,
-    );
+    await onMessageDestroyThingVisorAck(res);
   }
 };
 
 export const onMessageCreateVThing = async(res: any) => {
   try{
+    logger.debug("Creating VThing" + res.vThing.id);
     const tvID = res.thingVisorID;
     const contract = await getContract(thingVisorUser.get(res.thingVisorID)!);
     let cmdata = await contract.evaluateTransaction('ThingVisorRunning', tvID);
     let cm : ChaincodeMessage = JSON.parse(cmdata.toString());
     if(cm.message != MessageOK){
+      logger.debug("Waiting:" + res.vThing.id);
       while(cm.message != MessageOK){
         await new Promise(f => setTimeout(f, 1000));
         cmdata = await contract.evaluateTransaction('ThingVisorRunning', tvID);
@@ -57,6 +50,7 @@ export const onMessageDestroyThingVisorAck = async(res: any) => {
     const data = await contract.evaluateTransaction('GetThingVisor', tvID);
     const thingVisor = JSON.parse(data.toString());
     await contract.submitTransaction("DeleteThingVisor", tvID);
+    await contract.submitTransaction("DeleteAllVThingsFromThingVisor", tvID);
     if(!thingVisor.debug_mode){
       await deleteThingVisorOnKubernetes(thingVisor);
     }

--- a/scripts/collections_config.json
+++ b/scripts/collections_config.json
@@ -9,6 +9,15 @@
        "memberOnlyWrite": true
     },
     {
+      "name": "collectionvThingTVs",
+      "policy": "OR('Org1MSP.member', 'Org2MSP.member')",
+      "requiredPeerCount": 0,
+      "maxPeerCount": 16,
+      "blockToLive":1000000,
+      "memberOnlyRead": true,
+      "memberOnlyWrite": true
+   },
+    {
         "name": "collectionvThings",
         "policy": "OR('Org1MSP.member', 'Org2MSP.member')",
         "requiredPeerCount": 0,


### PR DESCRIPTION
## DONE
- [x] Handle MVCC_READ_CONFLICT when add or delete thingVisor
- [x] Move VThingTV model from ThingVisor and modify chaincode
- [x] Use CompositeKey to manage VThingTV Collection in chaincode
- [x] Parallize deleteVThingTV using `Promise.all`
- [x] add retry for updateThingVisor and increase concurrency of jobQueue 